### PR TITLE
Fix for FileField's value filled without filename

### DIFF
--- a/lib/fields/file_field.dart
+++ b/lib/fields/file_field.dart
@@ -142,7 +142,7 @@ class FileField extends FormFieldResponsive<Uint8List> {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceAround,
                         children: <Widget>[
-                          if (state._filename != null) ...<Widget>[
+                          if (state.value != null) ...<Widget>[
                             // Thumbnail & Filename
                             Expanded(
                               flex: 2,
@@ -172,11 +172,12 @@ class FileField extends FormFieldResponsive<Uint8List> {
                                         ),
                                       ),
                                     ),
-                                  Text(
-                                    textAlign: TextAlign.center,
-                                    state._filename!,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
+                                  if (state._filename != null)
+                                    Text(
+                                      textAlign: TextAlign.center,
+                                      state._filename!,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
                                 ],
                               ),
                             ),
@@ -200,6 +201,8 @@ class FileField extends FormFieldResponsive<Uint8List> {
                                 : Column(
                                     crossAxisAlignment:
                                         CrossAxisAlignment.stretch,
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceEvenly,
                                     children: <Widget>[
                                       deleteWidget,
                                       loadWidget


### PR DESCRIPTION
FileField can be pre-filled with initialValue and `state._filename` will therefore be null. Some `if` conditions to show image thumbnail or filename wasn't considering it.
This PR fix it.