### PR TITLE
Feature/no routing model function

### DIFF
--- a/lib/crud/abstract_function.dart
+++ b/lib/crud/abstract_function.dart
@@ -19,7 +19,7 @@ abstract class AbstractFunctionInterface<T> {
   ///
   ///
   ///
-  Widget? iconBuilder(T model) => null;
+  Widget? iconBuilder(BuildContext context, T model) => null;
 
   ///
   ///

--- a/lib/widgets/model_function_button.dart
+++ b/lib/widgets/model_function_button.dart
@@ -70,7 +70,7 @@ class ModelFunctionButtonState<T extends AbstractModel<Object>>
       builder: (BuildContext context, bool data) => data
           ? IconButton(
               tooltip: widget.permission.name,
-              icon: widget.rowFunction.iconBuilder(widget.model) ??
+              icon: widget.rowFunction.iconBuilder(context, widget.model) ??
                   IconHelper.faIcon(widget.permission.iconName),
               onPressed: () async {
                 Widget? nextWidget = await widget.rowFunction.onPressed(


### PR DESCRIPTION
These are some soft changes to allow a ModelFunction to not necessarily navigate to another page.
I think it is useful to have a more generic button on lists that do simple actions (i.e.: toggle a single property, like public visibility in my screenshot below)

![image](https://user-images.githubusercontent.com/12648211/181580933-fdf87407-3400-413d-9313-c7b55ce477e6.png)


I've changed ModelFunctionButton to StatefulWidget in order to allow dynamic icon building, but maybe there is other preferable way to do that.