### PR TITLE
Checking if abstract_list is still mounted after navigator popping it

### DIFF
--- a/lib/crud/abstract_list.dart
+++ b/lib/crud/abstract_list.dart
@@ -711,7 +711,9 @@ class AbstractListState<
         MaterialPageRoute<T>(builder: (_) => widget),
       );
 
-      await _loadData(context, clear: clear);
+      if (mounted) {
+        await _loadData(context, clear: clear);
+      }
     }
   }
 


### PR DESCRIPTION
A very simple safety check before calling `_loadData` in a place that widget is possibly unmounted.

I was getting this flutter error: 
`This widget has been unmounted, so the State no longer has a context (and should be considered defunct).`

When `context.goNamed('myroutename')` out of an abstract list 